### PR TITLE
fix: mapstructure replacement no longer needed

### DIFF
--- a/cmd/default_replacements.go
+++ b/cmd/default_replacements.go
@@ -17,7 +17,6 @@ func init() {
 		newVer string
 	}{
 		{"git.apache.org/thrift.git", "v0.0.0-20180902110319-2566ecd5d999", "github.com/apache/thrift", "v0.0.0-20180902110319-2566ecd5d999"},
-		{"github.com/go-viper/mapstructure/v2", "", "github.com/LumeWeb/mapstructure/v2", "v2.0.0-20241213212524-92525f5828be"},
 	}
 	// Loop through the list and create replacement rules
 	for _, repl := range replList {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request removes a dependency replacement for the `github.com/go-viper/mapstructure/v2` module from the default replacements configuration. The specific replacement that mapped `github.com/go-viper/mapstructure/v2` to `github.com/LumeWeb/mapstructure/v2` has been removed, indicating that this custom replacement is no longer necessary.
<!-- kody-pr-summary:end -->