### PR TITLE
fix: prevent protobuf rpc.proto registration panic

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -172,6 +172,10 @@ func (b Builder) Build(ctx context.Context, outputFile string) error {
 		fmt.Sprintf("-X %s/build.GoVersion=%s", defaultPortalModulePath, runtime.Version()),
 		fmt.Sprintf("-X %s/build.Platform=%s", defaultPortalModulePath, b.OS),
 		fmt.Sprintf("-X %s/build.Architecture=%s", defaultPortalModulePath, b.Arch),
+		// Prevent panic when two packages register the same proto file name
+		// (e.g. go-libp2p-pubsub and go.etcd.io/etcd both register "rpc.proto").
+		// See https://protobuf.dev/reference/go/faq#namespace-conflict
+		"-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=warn",
 	}
 
 	// Add build info for each plugin using resolved versions from Go

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -216,6 +216,10 @@ func finalizeBuild(output string) error {
 		fmt.Println()
 		fmt.Printf("%s version\n", output)
 		execCmd := exec.Command(output, "version")
+		// Set protobuf conflict policy to warn so that duplicate proto file
+		// registrations (e.g. rpc.proto from both go-libp2p-pubsub and etcd)
+		// emit a warning instead of panicking.
+		execCmd.Env = append(os.Environ(), "GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn")
 		execCmd.Stdout = os.Stdout
 		execCmd.Stderr = os.Stderr
 		err = execCmd.Run()


### PR DESCRIPTION
## Summary
- Add `-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=warn` ldflag to all builds so duplicate proto file registrations emit a warning instead of panicking
- Set `GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn` env var on the post-build `version` verification subprocess as belt-and-suspenders

When building portal with plugins that depend on `go-libp2p-pubsub` (e.g. `portal-plugin-ipfs`), the binary contains two packages that both register a proto file named `rpc.proto`: `go-libp2p-pubsub/pb` and `go.etcd.io/etcd/api/v3/etcdserverpb`. The protobuf global registry panics on the duplicate at init time, causing the `/dist/portal version` check to fail with exit code 2.

See https://protobuf.dev/reference/go/faq#namespace-conflict